### PR TITLE
Supporting impersonated service count (builds on #76)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rustls-pemfile = "1.0.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "1.0"
-time = { version = "0.3.5", features = ["serde"] }
+time = { version = "0.3.5", features = ["serde", "parsing"] }
 tokio = { version = "1.1", features = ["fs", "sync"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"

--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -2,9 +2,9 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::custom_service_account::CustomServiceAccount;
-use crate::default_authorized_user::ConfigDefaultCredentials;
 use crate::default_service_account::MetadataServiceAccount;
 use crate::error::Error;
+use crate::flexible_credential_source::FlexibleCredentialSource;
 use crate::gcloud_authorized_user::GCloudAuthorizedUser;
 use crate::types::{self, HyperClient, Token};
 
@@ -43,15 +43,25 @@ impl AuthenticationManager {
     #[tracing::instrument]
     pub async fn new() -> Result<Self, Error> {
         tracing::debug!("Initializing gcp_auth");
-        if let Some(service_account) = CustomServiceAccount::from_env()? {
-            return Ok(service_account.into());
+        let client = types::client();
+        if let Some(service_account) = FlexibleCredentialSource::from_env().await? {
+            tracing::debug!("Using GOOGLE_APPLICATION_CREDENTIALS env");
+
+            return Ok(Self {
+                service_account: service_account.try_into_service_account(&client).await?,
+                client,
+                refresh_mutex: Mutex::new(()),
+            });
         }
 
-        let client = types::client();
-        let default_user_error = match ConfigDefaultCredentials::new(&client).await {
+        let default_user_error = match FlexibleCredentialSource::from_default_credentials().await {
             Ok(service_account) => {
                 tracing::debug!("Using ConfigDefaultCredentials");
-                return Ok(Self::build(client, service_account));
+                return Ok(Self {
+                    service_account: service_account.try_into_service_account(&client).await?,
+                    client,
+                    refresh_mutex: Mutex::new(()),
+                });
             }
             Err(e) => e,
         };

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -54,7 +54,7 @@ impl CustomServiceAccount {
         }
     }
 
-    fn new(credentials: ApplicationCredentials) -> Result<Self, Error> {
+    pub(crate) fn new(credentials: ApplicationCredentials) -> Result<Self, Error> {
         Ok(Self {
             signer: Signer::new(&credentials.private_key)?,
             credentials,
@@ -137,7 +137,6 @@ impl ServiceAccount for CustomServiceAccount {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct ApplicationCredentials {
-    pub(crate) r#type: Option<String>,
     /// project_id
     pub(crate) project_id: Option<String>,
     /// private_key_id

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,10 @@ pub enum Error {
     #[error("Failed to parse output of GCloud")]
     GCloudParseError,
 
+    /// Currently, nested service account impersonation is not supported
+    #[error("Nested impersonation is not supported")]
+    NestedImpersonation,
+
     /// Represents all other cases of `std::io::Error`.
     #[error(transparent)]
     IOError(#[from] std::io::Error),

--- a/src/flexible_credential_source.rs
+++ b/src/flexible_credential_source.rs
@@ -1,0 +1,195 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+
+use crate::{
+    authentication_manager::ServiceAccount,
+    custom_service_account::ApplicationCredentials,
+    default_authorized_user::{ConfigDefaultCredentials, UserCredentials},
+    types::HyperClient,
+    CustomServiceAccount, Error,
+};
+
+// Implementation referenced from
+// https://github.com/golang/oauth2/blob/a835fc4358f6852f50c4c5c33fddcd1adade5b0a/google/google.go#L158
+// Currently not implementing external account credentials
+// Currently not implementing impersonating service accounts (coming soon !)
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum FlexibleCredentialSource {
+    // This credential parses the `key.json` file created when running
+    // `gcloud iam service-accounts keys create key.json --iam-account=SA_NAME@PROJECT_ID.iam.gserviceaccount.com`
+    ServiceAccount(ApplicationCredentials),
+    // This credential parses the `~/.config/gcloud/application_default_credentials.json` file
+    // created when running `gcloud auth application-default login`
+    AuthorizedUser(UserCredentials),
+}
+
+impl FlexibleCredentialSource {
+    const USER_CREDENTIALS_PATH: &'static str =
+        ".config/gcloud/application_default_credentials.json";
+
+    pub(crate) async fn from_env() -> Result<Option<Self>, Error> {
+        let creds_path = std::env::var_os("GOOGLE_APPLICATION_CREDENTIALS");
+        if let Some(path) = creds_path {
+            tracing::debug!("Reading credentials file from GOOGLE_APPLICATION_CREDENTIALS env var");
+            let creds = Self::from_file(PathBuf::from(path)).await?;
+            Ok(Some(creds))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) async fn from_default_credentials() -> Result<Self, Error> {
+        tracing::debug!("Loading user credentials file");
+        let mut home = dirs_next::home_dir().ok_or(Error::NoHomeDir)?;
+        home.push(Self::USER_CREDENTIALS_PATH);
+        Self::from_file(home).await
+    }
+
+    pub(crate) async fn try_into_service_account(
+        self,
+        client: &HyperClient,
+    ) -> Result<Box<dyn ServiceAccount>, Error> {
+        match self {
+            FlexibleCredentialSource::ServiceAccount(creds) => {
+                let service_account = CustomServiceAccount::new(creds)?;
+                Ok(Box::new(service_account))
+            }
+            FlexibleCredentialSource::AuthorizedUser(creds) => {
+                let service_account =
+                    ConfigDefaultCredentials::from_user_credentials(creds, client).await?;
+                Ok(Box::new(service_account))
+            }
+        }
+    }
+
+    /// Read service account credentials from the given JSON file
+    async fn from_file<T: AsRef<Path>>(path: T) -> Result<Self, Error> {
+        let creds_string = fs::read_to_string(&path)
+            .await
+            .map_err(Error::UserProfilePath)?;
+
+        serde_json::from_str::<FlexibleCredentialSource>(&creds_string)
+            .map_err(Error::CustomServiceAccountCredentials)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{flexible_credential_source::FlexibleCredentialSource, types};
+
+    #[tokio::test]
+    async fn test_parse_application_default_credentials() {
+        let test_creds = r#"{
+            "client_id": "***id***.apps.googleusercontent.com",
+            "client_secret": "***secret***",
+            "quota_project_id": "test_project",
+            "refresh_token": "***refresh***",
+            "type": "authorized_user"
+        }"#;
+
+        let cred_source: FlexibleCredentialSource =
+            serde_json::from_str(test_creds).expect("Valid creds to parse");
+
+        assert!(matches!(
+            cred_source,
+            FlexibleCredentialSource::AuthorizedUser(_)
+        ));
+
+        // Can't test converting this into a service account because it requires actually getting a key
+    }
+
+    #[tokio::test]
+    async fn test_parse_service_account_key() {
+        // Don't worry, even though the key is a real private_key, it's not used for anything
+        let test_creds = r#" {
+            "type": "service_account",
+            "project_id": "test_project",
+            "private_key_id": "***key_id***",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC5M5y3WwsRk8NX\npF9fKaZukNspot9Ecmk1PAkupcHLKVhalwPxU4sMNWXgM9H2LTWSvvyOT//rDQpn\n3SGYri/lMhzb4lI8h10E7k6zyFQUPujxkXFBkMOzhIDUgtiiht0WvIw6M8nbaPqI\nxn/aYmPsFhvJfKCthYAt2UUz+D3enI9QjCuhic8iSMnvKT8m0QkOG2eALYGUaLF1\ngRkbV4BiBUGZfXfNEBdux3Wf4kNUau32LA0XotomlvNvf1oH77v5Hc1R/KMMIk5F\nJWVBuAr4jwkN9hwtOozpJ/52wSpddxsZuj+0nP1a3f0UyvrmMnuwszardPK39BoH\nJ+5+HZM3AgMBAAECggEADrHZrXK73hkrVrjkGFjlq8Ayo4sYzAWH84Ff+SONzODq\n8cUpuuw2DDHwc2mpLy9HIO2mfGQ8mhneyX7yO3sWscjYIVpDzCmxZ8LA2+L5SOH0\n+bXglqM14/iPgE0hg0PQJw2u0q9pRM9/kXquilVkOEdIzSPmW95L3Vdv9j+sKQ2A\nOL23l4dsaG4+i1lWRBKiGsLh1kB9FRnm4BzcOxd3WGooy7L1/jo9BoYRss1YABls\nmmyZ9f7r28zjclhpOBkE3OXX0zNbp4yIu1O1Bt9X2p87EOuYqlFA5eEvDbiTPZbk\n6wKEX3BPUkeIo8OaGvsGhHCWx0lv/sDPw/UofycOgQKBgQD4BD059aXEV13Byc5D\nh8LQSejjeM/Vx+YeCFI66biaIOvUs+unyxkH+qxXTuW6AgOgcvrJo93xkyAZ9SeR\nc6Vj9g5mZ5vqSJz5Hg8h8iZBAYtf40qWq0pHcmUIm2Z9LvrG5ZFHU5EEcCtLyBVS\nAv+pLLLf3OsAkJuuqTAgygBbOwKBgQC/KcBa9sUg2u9qIpq020UOW/n4KFWhSJ8h\ngXqqmjOnPqmDc5AnYg1ZdYdqSSgdiK8lJpRL/S2UjYUQp3H+56z0eK/b1iKM51n+\n6D80nIxWeKJ+n7VKI7cBXwc/KokaXgkz0It2UEZSlhPUMImnYcOvGIZ7cMr3Q6mf\n6FwD15UQNQKBgQDyAsDz454DvvS/+noJL1qMAPL9tI+pncwQljIXRqVZ0LIO9hoH\nu4kLXjH5aAWGwhxj3o6VYA9cgSIb8jrQFbbXmexnRMbBkGWMOSavCykE2cr0oEfS\nSgbLPPcVtP4HPWZ72tsubH7fg8zbv7v+MOrkW7eX9mxiOrmPb4yFElfSrQKBgA7y\nMLvr91WuSHG/6uChFDEfN9gTLz7A8tAn03NrQwace5xveKHbpLeN3NyOg7hra2Y4\nMfgO/3VR60l2Dg+kBX3HwdgqUeE6ZWrstaRjaQWJwQqtafs196T/zQ0/QiDxoT6P\n25eQhy8F1N8OPHT9y9Lw0/LqyrOycpyyCh+yx1DRAoGAJ/6dlhyQnwSfMAe3mfRC\noiBQG6FkyoeXHHYcoQ/0cSzwp0BwBlar1Z28P7KTGcUNqV+YfK9nF47eoLaTLCmG\nG5du0Ds6m2Eg0sOBBqXHnw6R1PC878tgT/XokNxIsVlF5qRz88q7Rn0J1lzB7+Tl\n2HSAcyIUcmr0gxlhRmC2Jq4=\n-----END PRIVATE KEY-----\n",
+            "client_email": "test_account@test.iam.gserviceaccount.com",
+            "client_id": "***id***",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test_account%40test.iam.gserviceaccount.com",
+            "universe_domain": "googleapis.com"
+        }"#;
+
+        let cred_source: FlexibleCredentialSource =
+            serde_json::from_str(test_creds).expect("Valid creds to parse");
+
+        assert!(matches!(
+            cred_source,
+            FlexibleCredentialSource::ServiceAccount(_)
+        ));
+
+        let client = types::client();
+        let creds = cred_source
+            .try_into_service_account(&client)
+            .await
+            .expect("Valid creds to parse");
+
+        assert_eq!(
+            creds
+                .project_id(&client)
+                .await
+                .expect("Project ID to be present"),
+            "test_project".to_string(),
+            "Project ID should be parsed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_additional_service_account_keys() {
+        // Using test cases from https://github.com/golang/oauth2/blob/a835fc4358f6852f50c4c5c33fddcd1adade5b0a/google/google_test.go#L40
+        // We have to use a real private key because we validate private keys on parsing as well.
+        let k1 = r#"{
+            "private_key_id": "268f54e43a1af97cfc71731688434f45aca15c8b",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC5M5y3WwsRk8NX\npF9fKaZukNspot9Ecmk1PAkupcHLKVhalwPxU4sMNWXgM9H2LTWSvvyOT//rDQpn\n3SGYri/lMhzb4lI8h10E7k6zyFQUPujxkXFBkMOzhIDUgtiiht0WvIw6M8nbaPqI\nxn/aYmPsFhvJfKCthYAt2UUz+D3enI9QjCuhic8iSMnvKT8m0QkOG2eALYGUaLF1\ngRkbV4BiBUGZfXfNEBdux3Wf4kNUau32LA0XotomlvNvf1oH77v5Hc1R/KMMIk5F\nJWVBuAr4jwkN9hwtOozpJ/52wSpddxsZuj+0nP1a3f0UyvrmMnuwszardPK39BoH\nJ+5+HZM3AgMBAAECggEADrHZrXK73hkrVrjkGFjlq8Ayo4sYzAWH84Ff+SONzODq\n8cUpuuw2DDHwc2mpLy9HIO2mfGQ8mhneyX7yO3sWscjYIVpDzCmxZ8LA2+L5SOH0\n+bXglqM14/iPgE0hg0PQJw2u0q9pRM9/kXquilVkOEdIzSPmW95L3Vdv9j+sKQ2A\nOL23l4dsaG4+i1lWRBKiGsLh1kB9FRnm4BzcOxd3WGooy7L1/jo9BoYRss1YABls\nmmyZ9f7r28zjclhpOBkE3OXX0zNbp4yIu1O1Bt9X2p87EOuYqlFA5eEvDbiTPZbk\n6wKEX3BPUkeIo8OaGvsGhHCWx0lv/sDPw/UofycOgQKBgQD4BD059aXEV13Byc5D\nh8LQSejjeM/Vx+YeCFI66biaIOvUs+unyxkH+qxXTuW6AgOgcvrJo93xkyAZ9SeR\nc6Vj9g5mZ5vqSJz5Hg8h8iZBAYtf40qWq0pHcmUIm2Z9LvrG5ZFHU5EEcCtLyBVS\nAv+pLLLf3OsAkJuuqTAgygBbOwKBgQC/KcBa9sUg2u9qIpq020UOW/n4KFWhSJ8h\ngXqqmjOnPqmDc5AnYg1ZdYdqSSgdiK8lJpRL/S2UjYUQp3H+56z0eK/b1iKM51n+\n6D80nIxWeKJ+n7VKI7cBXwc/KokaXgkz0It2UEZSlhPUMImnYcOvGIZ7cMr3Q6mf\n6FwD15UQNQKBgQDyAsDz454DvvS/+noJL1qMAPL9tI+pncwQljIXRqVZ0LIO9hoH\nu4kLXjH5aAWGwhxj3o6VYA9cgSIb8jrQFbbXmexnRMbBkGWMOSavCykE2cr0oEfS\nSgbLPPcVtP4HPWZ72tsubH7fg8zbv7v+MOrkW7eX9mxiOrmPb4yFElfSrQKBgA7y\nMLvr91WuSHG/6uChFDEfN9gTLz7A8tAn03NrQwace5xveKHbpLeN3NyOg7hra2Y4\nMfgO/3VR60l2Dg+kBX3HwdgqUeE6ZWrstaRjaQWJwQqtafs196T/zQ0/QiDxoT6P\n25eQhy8F1N8OPHT9y9Lw0/LqyrOycpyyCh+yx1DRAoGAJ/6dlhyQnwSfMAe3mfRC\noiBQG6FkyoeXHHYcoQ/0cSzwp0BwBlar1Z28P7KTGcUNqV+YfK9nF47eoLaTLCmG\nG5du0Ds6m2Eg0sOBBqXHnw6R1PC878tgT/XokNxIsVlF5qRz88q7Rn0J1lzB7+Tl\n2HSAcyIUcmr0gxlhRmC2Jq4=\n-----END PRIVATE KEY-----\n",
+            "client_email": "gopher@developer.gserviceaccount.com",
+            "client_id": "gopher.apps.googleusercontent.com",
+            "token_uri": "https://accounts.google.com/o/gophers/token",
+            "type": "service_account",
+            "audience": "https://testservice.googleapis.com/"
+        }"#;
+
+        let k3 = r#"{
+            "private_key_id": "268f54e43a1af97cfc71731688434f45aca15c8b",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC5M5y3WwsRk8NX\npF9fKaZukNspot9Ecmk1PAkupcHLKVhalwPxU4sMNWXgM9H2LTWSvvyOT//rDQpn\n3SGYri/lMhzb4lI8h10E7k6zyFQUPujxkXFBkMOzhIDUgtiiht0WvIw6M8nbaPqI\nxn/aYmPsFhvJfKCthYAt2UUz+D3enI9QjCuhic8iSMnvKT8m0QkOG2eALYGUaLF1\ngRkbV4BiBUGZfXfNEBdux3Wf4kNUau32LA0XotomlvNvf1oH77v5Hc1R/KMMIk5F\nJWVBuAr4jwkN9hwtOozpJ/52wSpddxsZuj+0nP1a3f0UyvrmMnuwszardPK39BoH\nJ+5+HZM3AgMBAAECggEADrHZrXK73hkrVrjkGFjlq8Ayo4sYzAWH84Ff+SONzODq\n8cUpuuw2DDHwc2mpLy9HIO2mfGQ8mhneyX7yO3sWscjYIVpDzCmxZ8LA2+L5SOH0\n+bXglqM14/iPgE0hg0PQJw2u0q9pRM9/kXquilVkOEdIzSPmW95L3Vdv9j+sKQ2A\nOL23l4dsaG4+i1lWRBKiGsLh1kB9FRnm4BzcOxd3WGooy7L1/jo9BoYRss1YABls\nmmyZ9f7r28zjclhpOBkE3OXX0zNbp4yIu1O1Bt9X2p87EOuYqlFA5eEvDbiTPZbk\n6wKEX3BPUkeIo8OaGvsGhHCWx0lv/sDPw/UofycOgQKBgQD4BD059aXEV13Byc5D\nh8LQSejjeM/Vx+YeCFI66biaIOvUs+unyxkH+qxXTuW6AgOgcvrJo93xkyAZ9SeR\nc6Vj9g5mZ5vqSJz5Hg8h8iZBAYtf40qWq0pHcmUIm2Z9LvrG5ZFHU5EEcCtLyBVS\nAv+pLLLf3OsAkJuuqTAgygBbOwKBgQC/KcBa9sUg2u9qIpq020UOW/n4KFWhSJ8h\ngXqqmjOnPqmDc5AnYg1ZdYdqSSgdiK8lJpRL/S2UjYUQp3H+56z0eK/b1iKM51n+\n6D80nIxWeKJ+n7VKI7cBXwc/KokaXgkz0It2UEZSlhPUMImnYcOvGIZ7cMr3Q6mf\n6FwD15UQNQKBgQDyAsDz454DvvS/+noJL1qMAPL9tI+pncwQljIXRqVZ0LIO9hoH\nu4kLXjH5aAWGwhxj3o6VYA9cgSIb8jrQFbbXmexnRMbBkGWMOSavCykE2cr0oEfS\nSgbLPPcVtP4HPWZ72tsubH7fg8zbv7v+MOrkW7eX9mxiOrmPb4yFElfSrQKBgA7y\nMLvr91WuSHG/6uChFDEfN9gTLz7A8tAn03NrQwace5xveKHbpLeN3NyOg7hra2Y4\nMfgO/3VR60l2Dg+kBX3HwdgqUeE6ZWrstaRjaQWJwQqtafs196T/zQ0/QiDxoT6P\n25eQhy8F1N8OPHT9y9Lw0/LqyrOycpyyCh+yx1DRAoGAJ/6dlhyQnwSfMAe3mfRC\noiBQG6FkyoeXHHYcoQ/0cSzwp0BwBlar1Z28P7KTGcUNqV+YfK9nF47eoLaTLCmG\nG5du0Ds6m2Eg0sOBBqXHnw6R1PC878tgT/XokNxIsVlF5qRz88q7Rn0J1lzB7+Tl\n2HSAcyIUcmr0gxlhRmC2Jq4=\n-----END PRIVATE KEY-----\n",
+            "client_email": "gopher@developer.gserviceaccount.com",
+            "client_id": "gopher.apps.googleusercontent.com",
+            "token_uri": "https://accounts.google.com/o/gophers/token",
+            "type": "service_account"
+        }"#;
+
+        let client = types::client();
+        for key in [k1, k3] {
+            let cred_source: FlexibleCredentialSource =
+                serde_json::from_str(key).expect("Valid creds to parse");
+
+            assert!(matches!(
+                cred_source,
+                FlexibleCredentialSource::ServiceAccount(_)
+            ));
+
+            let creds = cred_source
+                .try_into_service_account(&client)
+                .await
+                .expect("Valid creds to parse");
+
+            assert!(
+                matches!(
+                    creds
+                        .project_id(&client)
+                        .await
+                        .expect_err("Project ID to not be present"),
+                    crate::Error::ProjectIdNotFound,
+                ),
+                "Project id should not be found here",
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ mod error;
 mod flexible_credential_source;
 mod gcloud_authorized_user;
 mod jwt;
+mod service_account_impersonation;
 mod types;
 mod util;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ mod custom_service_account;
 mod default_authorized_user;
 mod default_service_account;
 mod error;
+mod flexible_credential_source;
 mod gcloud_authorized_user;
 mod jwt;
 mod types;

--- a/src/service_account_impersonation.rs
+++ b/src/service_account_impersonation.rs
@@ -1,0 +1,173 @@
+use async_trait::async_trait;
+use std::{collections::HashMap, sync::RwLock};
+use time::{format_description::well_known::Iso8601, OffsetDateTime};
+
+use hyper::header;
+use serde::{de, Deserialize, Deserializer, Serialize};
+
+use crate::{
+    authentication_manager::ServiceAccount, gcloud_authorized_user::DEFAULT_TOKEN_DURATION,
+    types::HyperClient, util::HyperExt, Error, Token,
+};
+
+// This credential uses the `source_credentials` to get a token
+// and then uses that token to get a token impersonating the service
+// account specified by `service_account_impersonation_url`.
+// refresh logic https://github.com/golang/oauth2/blob/a835fc4358f6852f50c4c5c33fddcd1adade5b0a/google/internal/externalaccount/impersonate.go#L57
+//
+// In practice, the api currently referred to by `service_account_impersonation_url` is
+// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+pub(crate) struct ImpersonatedServiceAccount {
+    service_account_impersonation_url: String,
+    source_credentials: Box<dyn ServiceAccount>,
+    delegates: Vec<String>,
+    tokens: RwLock<HashMap<Vec<String>, Token>>,
+}
+
+impl ImpersonatedServiceAccount {
+    pub(crate) fn new(
+        source_credentials: Box<dyn ServiceAccount>,
+        service_account_impersonation_url: String,
+        delegates: Vec<String>,
+    ) -> Self {
+        Self {
+            service_account_impersonation_url,
+            source_credentials,
+            delegates,
+            tokens: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl std::fmt::Debug for ImpersonatedServiceAccount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImpersonatedServiceAccount")
+            .field(
+                "service_account_impersonation_url",
+                &self.service_account_impersonation_url,
+            )
+            .field("source_credentials", &"Box<dyn ServiceAccount>")
+            .field("delegates", &self.delegates)
+            .finish()
+    }
+}
+
+// This is the impersonation token described by this documentation
+// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImpersonationTokenResponse {
+    access_token: String,
+    #[serde(deserialize_with = "deserialize_rfc3339")]
+    expire_time: OffsetDateTime,
+}
+
+fn deserialize_rfc3339<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // First try to deserialize seconds
+    let time_str: String = Deserialize::deserialize(deserializer)?;
+
+    OffsetDateTime::parse(&time_str, &Iso8601::PARSING).map_err(de::Error::custom)
+}
+
+impl From<ImpersonationTokenResponse> for Token {
+    fn from(value: ImpersonationTokenResponse) -> Self {
+        Token::new(value.access_token, value.expire_time)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_impersonation_token() {
+        let resp_body = "{\n  \"accessToken\": \"secret_token\",\n  \"expireTime\": \"2023-08-18T04:09:45Z\"\n}";
+        let token: ImpersonationTokenResponse =
+            serde_json::from_str(resp_body).expect("Failed to parse token");
+        assert_eq!(token.access_token, "secret_token");
+    }
+}
+
+#[async_trait]
+impl ServiceAccount for ImpersonatedServiceAccount {
+    async fn project_id(&self, hc: &HyperClient) -> Result<String, Error> {
+        self.source_credentials.project_id(hc).await
+    }
+
+    fn get_token(&self, scopes: &[&str]) -> Option<Token> {
+        let key: Vec<_> = scopes.iter().map(|x| x.to_string()).collect();
+        self.tokens.read().unwrap().get(&key).cloned()
+    }
+
+    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str]) -> Result<Token, Error> {
+        let source_token = self
+            .source_credentials
+            .refresh_token(client, scopes)
+            .await?;
+
+        // Then we do a request to get the impersonated token
+        let lifetime_seconds = DEFAULT_TOKEN_DURATION.whole_seconds();
+        #[derive(Serialize, Clone)]
+        // Format from https://github.com/golang/oauth2/blob/a835fc4358f6852f50c4c5c33fddcd1adade5b0a/google/internal/externalaccount/impersonate.go#L21
+        struct AccessTokenRequest {
+            lifetime: String,
+            #[serde(skip_serializing_if = "Vec::is_empty")]
+            scope: Vec<String>,
+            #[serde(skip_serializing_if = "Vec::is_empty")]
+            delegates: Vec<String>,
+        }
+
+        let request = AccessTokenRequest {
+            lifetime: format!("{lifetime_seconds}s"),
+            scope: scopes.iter().map(|s| s.to_string()).collect(),
+            delegates: self.delegates.clone(),
+        };
+        let rqbody =
+            serde_json::to_string(&request).expect("access token request failed to serialize");
+
+        let token_uri = self.service_account_impersonation_url.as_str();
+
+        let mut retries = 0;
+        let response = loop {
+            // We assume bearer tokens only. In the referenced code, other token types are possible
+            // https://github.com/golang/oauth2/blob/a835fc4358f6852f50c4c5c33fddcd1adade5b0a/token.go#L84
+            let request = hyper::Request::post(token_uri)
+                .header(
+                    header::AUTHORIZATION,
+                    format!("Bearer {}", source_token.as_str()),
+                )
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(hyper::Body::from(rqbody.clone()))
+                .unwrap();
+
+            tracing::debug!("requesting impersonation token from service account: {request:?}");
+            let err = match client.request(request).await {
+                // Early return when the request succeeds
+                Ok(response) => break response,
+                Err(err) => err,
+            };
+
+            tracing::warn!(
+                "Failed to refresh impersonation token with service token endpoint {token_uri}: {err}, trying again..."
+            );
+            retries += 1;
+            if retries >= RETRY_COUNT {
+                return Err(Error::OAuthConnectionError(err));
+            }
+        };
+
+        let token_response: ImpersonationTokenResponse = response.deserialize().await?;
+        let token: Token = token_response.into();
+
+        let key = scopes.iter().map(|x| (*x).to_string()).collect();
+        self.tokens.write().unwrap().insert(key, token.clone());
+
+        Ok(token)
+    }
+}
+
+/// How many times to attempt to fetch a token from the set credentials token endpoint.
+const RETRY_COUNT: u8 = 5;

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,6 +31,15 @@ pub struct Token {
 }
 
 impl Token {
+    pub(crate) fn new(access_token: String, expires_at: OffsetDateTime) -> Self {
+        Token {
+            inner: Arc::new(InnerToken {
+                access_token,
+                expires_at,
+            }),
+        }
+    }
+
     pub(crate) fn from_string(access_token: String, expires_in: Duration) -> Self {
         Token {
             inner: Arc::new(InnerToken {


### PR DESCRIPTION
This PR adds service account impersonation. It uses a generic `Box<dyn ServiceAccount>` to get the source token and then uses that token to refresh the impersonated account from the `service_account_impersonation_url`.