### PR TITLE
Add support for providing subject for JWT claim when gettng token

### DIFF
--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -12,7 +12,7 @@ use crate::types::{self, HyperClient, Token};
 pub(crate) trait ServiceAccount: Send + Sync {
     async fn project_id(&self, client: &HyperClient) -> Result<String, Error>;
     fn get_token(&self, scopes: &[&str]) -> Option<Token>;
-    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str],subject: Option<&str>) -> Result<Token, Error>;
+    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str], subject: Option<&str>) -> Result<Token, Error>;
 }
 
 /// Authentication manager is responsible for caching and obtaining credentials for the required
@@ -98,7 +98,7 @@ impl AuthenticationManager {
     ///
     /// Token can be used in the request authorization header in format "Bearer {token}",
     /// subject is used to impersonate a user, if None, the service account is used
-    pub async fn get_token_with_subject(&self, scopes: &[&str],subject: Option<&str>) -> Result<Token, Error> {
+    pub async fn get_token_with_subject(&self, scopes: &[&str], subject: Option<&str>) -> Result<Token, Error> {
         let token = self.service_account.get_token(scopes);
         if let Some(token) = token.filter(|token| !token.has_expired()) {
             return Ok(token);
@@ -113,7 +113,7 @@ impl AuthenticationManager {
         }
 
         self.service_account
-            .refresh_token(&self.client, scopes,subject)
+            .refresh_token(&self.client, scopes, subject)
             .await
     }
 

--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -12,7 +12,7 @@ use crate::types::{self, HyperClient, Token};
 pub(crate) trait ServiceAccount: Send + Sync {
     async fn project_id(&self, client: &HyperClient) -> Result<String, Error>;
     fn get_token(&self, scopes: &[&str]) -> Option<Token>;
-    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str]) -> Result<Token, Error>;
+    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str],subject: Option<&str>) -> Result<Token, Error>;
 }
 
 /// Authentication manager is responsible for caching and obtaining credentials for the required
@@ -91,6 +91,14 @@ impl AuthenticationManager {
     ///
     /// Token can be used in the request authorization header in format "Bearer {token}"
     pub async fn get_token(&self, scopes: &[&str]) -> Result<Token, Error> {
+        self.get_token_with_subject(scopes,None).await
+    }
+
+    /// Requests Bearer token for the provided scope
+    ///
+    /// Token can be used in the request authorization header in format "Bearer {token}",
+    /// subject is used to impersonate a user, if None, the service account is used
+    pub async fn get_token_with_subject(&self, scopes: &[&str],subject: Option<&str>) -> Result<Token, Error> {
         let token = self.service_account.get_token(scopes);
         if let Some(token) = token.filter(|token| !token.has_expired()) {
             return Ok(token);
@@ -105,7 +113,7 @@ impl AuthenticationManager {
         }
 
         self.service_account
-            .refresh_token(&self.client, scopes)
+            .refresh_token(&self.client, scopes,subject)
             .await
     }
 

--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -12,7 +12,12 @@ use crate::types::{self, HyperClient, Token};
 pub(crate) trait ServiceAccount: Send + Sync {
     async fn project_id(&self, client: &HyperClient) -> Result<String, Error>;
     fn get_token(&self, scopes: &[&str]) -> Option<Token>;
-    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str], subject: Option<&str>) -> Result<Token, Error>;
+    async fn refresh_token(
+        &self,
+        client: &HyperClient,
+        scopes: &[&str],
+        subject: Option<&str>,
+    ) -> Result<Token, Error>;
 }
 
 /// Authentication manager is responsible for caching and obtaining credentials for the required
@@ -91,14 +96,18 @@ impl AuthenticationManager {
     ///
     /// Token can be used in the request authorization header in format "Bearer {token}"
     pub async fn get_token(&self, scopes: &[&str]) -> Result<Token, Error> {
-        self.get_token_with_subject(scopes,None).await
+        self.get_token_with_subject(scopes, None).await
     }
 
     /// Requests Bearer token for the provided scope
     ///
     /// Token can be used in the request authorization header in format "Bearer {token}",
     /// subject is used to impersonate a user, if None, the service account is used
-    pub async fn get_token_with_subject(&self, scopes: &[&str], subject: Option<&str>) -> Result<Token, Error> {
+    pub async fn get_token_with_subject(
+        &self,
+        scopes: &[&str],
+        subject: Option<&str>,
+    ) -> Result<Token, Error> {
         let token = self.service_account.get_token(scopes);
         if let Some(token) = token.filter(|token| !token.has_expired()) {
             return Ok(token);

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -93,13 +93,13 @@ impl ServiceAccount for CustomServiceAccount {
     }
 
     #[tracing::instrument]
-    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str]) -> Result<Token, Error> {
+    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str], subject: Option<&str>) -> Result<Token, Error> {
         use crate::jwt::Claims;
         use crate::jwt::GRANT_TYPE;
         use hyper::header;
         use url::form_urlencoded;
 
-        let jwt = Claims::new(&self.credentials, scopes, None).to_jwt(&self.signer)?;
+        let jwt = Claims::new(&self.credentials, scopes, subject).to_jwt(&self.signer)?;
         let rqbody = form_urlencoded::Serializer::new(String::new())
             .extend_pairs(&[("grant_type", GRANT_TYPE), ("assertion", jwt.as_str())])
             .finish();

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -93,7 +93,12 @@ impl ServiceAccount for CustomServiceAccount {
     }
 
     #[tracing::instrument]
-    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str], subject: Option<&str>) -> Result<Token, Error> {
+    async fn refresh_token(
+        &self,
+        client: &HyperClient,
+        scopes: &[&str],
+        subject: Option<&str>,
+    ) -> Result<Token, Error> {
         use crate::jwt::Claims;
         use crate::jwt::GRANT_TYPE;
         use hyper::header;

--- a/src/default_authorized_user.rs
+++ b/src/default_authorized_user.rs
@@ -89,7 +89,7 @@ impl ServiceAccount for ConfigDefaultCredentials {
         Some(self.token.read().unwrap().clone())
     }
 
-    async fn refresh_token(&self, client: &HyperClient, _scopes: &[&str]) -> Result<Token, Error> {
+    async fn refresh_token(&self, client: &HyperClient, _scopes: &[&str],_subject: Option<&str>) -> Result<Token, Error> {
         let token = Self::get_token(&self.credentials, client).await?;
         *self.token.write().unwrap() = token.clone();
         Ok(token)

--- a/src/default_authorized_user.rs
+++ b/src/default_authorized_user.rs
@@ -89,7 +89,12 @@ impl ServiceAccount for ConfigDefaultCredentials {
         Some(self.token.read().unwrap().clone())
     }
 
-    async fn refresh_token(&self, client: &HyperClient, _scopes: &[&str],_subject: Option<&str>) -> Result<Token, Error> {
+    async fn refresh_token(
+        &self,
+        client: &HyperClient,
+        _scopes: &[&str],
+        _subject: Option<&str>,
+    ) -> Result<Token, Error> {
         let token = Self::get_token(&self.credentials, client).await?;
         *self.token.write().unwrap() = token.clone();
         Ok(token)

--- a/src/default_service_account.rs
+++ b/src/default_service_account.rs
@@ -81,7 +81,12 @@ impl ServiceAccount for MetadataServiceAccount {
         Some(self.token.read().unwrap().clone())
     }
 
-    async fn refresh_token(&self, client: &HyperClient, _scopes: &[&str],_subect: Option<&str>) -> Result<Token, Error> {
+    async fn refresh_token(
+        &self,
+        client: &HyperClient,
+        _scopes: &[&str],
+        _subect: Option<&str>,
+    ) -> Result<Token, Error> {
         let token = Self::get_token(client).await?;
         *self.token.write().unwrap() = token.clone();
         Ok(token)

--- a/src/default_service_account.rs
+++ b/src/default_service_account.rs
@@ -81,7 +81,7 @@ impl ServiceAccount for MetadataServiceAccount {
         Some(self.token.read().unwrap().clone())
     }
 
-    async fn refresh_token(&self, client: &HyperClient, _scopes: &[&str]) -> Result<Token, Error> {
+    async fn refresh_token(&self, client: &HyperClient, _scopes: &[&str],_subect: Option<&str>) -> Result<Token, Error> {
         let token = Self::get_token(client).await?;
         *self.token.write().unwrap() = token.clone();
         Ok(token)

--- a/src/gcloud_authorized_user.rs
+++ b/src/gcloud_authorized_user.rs
@@ -54,7 +54,12 @@ impl ServiceAccount for GCloudAuthorizedUser {
         Some(self.token.read().unwrap().clone())
     }
 
-    async fn refresh_token(&self, _client: &HyperClient, _scopes: &[&str],_subject: Option<&str>) -> Result<Token, Error> {
+    async fn refresh_token(
+        &self,
+        _client: &HyperClient,
+        _scopes: &[&str],
+        _subject: Option<&str>,
+    ) -> Result<Token, Error> {
         let token = Self::token(&self.gcloud)?;
         *self.token.write().unwrap() = token.clone();
         Ok(token)

--- a/src/gcloud_authorized_user.rs
+++ b/src/gcloud_authorized_user.rs
@@ -54,7 +54,7 @@ impl ServiceAccount for GCloudAuthorizedUser {
         Some(self.token.read().unwrap().clone())
     }
 
-    async fn refresh_token(&self, _client: &HyperClient, _scopes: &[&str]) -> Result<Token, Error> {
+    async fn refresh_token(&self, _client: &HyperClient, _scopes: &[&str],_subject: Option<&str>) -> Result<Token, Error> {
         let token = Self::token(&self.gcloud)?;
         *self.token.write().unwrap() = token.clone();
         Ok(token)

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -19,7 +19,7 @@ pub(crate) struct Claims<'a> {
     aud: &'a str,
     exp: i64,
     iat: i64,
-    subject: Option<&'a str>,
+    sub: Option<&'a str>,
     scope: String,
 }
 
@@ -45,7 +45,7 @@ impl<'a> Claims<'a> {
             aud: &key.token_uri,
             exp: expiry,
             iat,
-            subject,
+            sub: subject,
             scope,
         }
     }


### PR DESCRIPTION
This is useful when you want to access stuff like [Google Workspace API](https://developers.google.com/admin-sdk/alertcenter/reference/rest), where you can't just use service account but need to impersonate use with correct rights in google workspace.

Tested it with my code and was able to access google workspace alerts.

If needed I can tweak naming of `get_token_with_subject` and comment, but otherwise looks it fits.