### PR TITLE
Update env_logger to 0.11

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.70.0"
+          toolchain: "1.71.0"
       - run: cargo check --lib --all-features
 
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,5 @@ url = "2"
 which = "6.0"
 
 [dev-dependencies]
-env_logger = "0.10"
+env_logger = "0.11"
 tokio = { version = "1.1", features = ["macros", "parking_lot", "rt-multi-thread"] }


### PR DESCRIPTION
Needs an MSRV bump. Replaces #97.