### PR TITLE
Reduce instrument logging level to debug

### DIFF
--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use tokio::sync::Mutex;
+use tracing::{instrument, Level};
 
 use crate::custom_service_account::CustomServiceAccount;
 use crate::default_authorized_user::ConfigDefaultCredentials;
@@ -40,7 +41,7 @@ impl AuthenticationManager {
     ///    if it succeeds, use the default service account as the token source.
     /// 4. Check if the `gcloud` tool is available on the `PATH`; if so, use the
     ///    `gcloud auth print-access-token` command as the token source.
-    #[tracing::instrument]
+    #[instrument(level = Level::DEBUG)]
     pub async fn new() -> Result<Self, Error> {
         tracing::debug!("Initializing gcp_auth");
         if let Some(service_account) = CustomServiceAccount::from_env()? {

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -5,6 +5,7 @@ use std::sync::RwLock;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use tracing::{instrument, Level};
 
 use crate::authentication_manager::ServiceAccount;
 use crate::error::Error;
@@ -92,7 +93,7 @@ impl ServiceAccount for CustomServiceAccount {
         self.tokens.read().unwrap().get(&key).cloned()
     }
 
-    #[tracing::instrument]
+    #[instrument(level = Level::DEBUG)]
     async fn refresh_token(&self, client: &HyperClient, scopes: &[&str]) -> Result<Token, Error> {
         use crate::jwt::Claims;
         use crate::jwt::GRANT_TYPE;

--- a/src/default_authorized_user.rs
+++ b/src/default_authorized_user.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use hyper::body::Body;
 use hyper::{Method, Request};
 use serde::{Deserialize, Serialize};
+use tracing::{instrument, Level};
 
 use crate::authentication_manager::ServiceAccount;
 use crate::error::Error;
@@ -46,7 +47,7 @@ impl ConfigDefaultCredentials {
             .unwrap()
     }
 
-    #[tracing::instrument]
+    #[instrument(level = Level::DEBUG)]
     async fn get_token(cred: &UserCredentials, client: &HyperClient) -> Result<Token, Error> {
         let mut retries = 0;
         let response = loop {

--- a/src/default_service_account.rs
+++ b/src/default_service_account.rs
@@ -4,6 +4,7 @@ use std::sync::RwLock;
 use async_trait::async_trait;
 use hyper::body::Body;
 use hyper::{Method, Request};
+use tracing::{instrument, Level};
 
 use crate::authentication_manager::ServiceAccount;
 use crate::error::Error;
@@ -34,7 +35,7 @@ impl MetadataServiceAccount {
             .unwrap()
     }
 
-    #[tracing::instrument]
+    #[instrument(level = Level::DEBUG)]
     async fn get_token(client: &HyperClient) -> Result<Token, Error> {
         let mut retries = 0;
         tracing::debug!("Getting token from GCP instance metadata server");


### PR DESCRIPTION
Closes #100 by reducing the log level to `debug` when using the `instrument` attribute macro. This will avoid polluting the `INFO` logs of downstream users with calls to `gcp_auth` unless they intentionally turn on the `debug` logging levels.