### PR TITLE
Load default credentials from right path on Windows

### DIFF
--- a/src/config_default_credentials.rs
+++ b/src/config_default_credentials.rs
@@ -121,10 +121,9 @@ fn config_dir() -> Result<PathBuf, Error> {
         .map_err(|_| Error::Str("APPDATA environment variable not found"))?;
     let config_path = PathBuf::from(app_data);
     match config_path.exists() {
-        true => Ok(home),
+        true => Ok(config_path),
         false => Err(Error::Str("APPDATA directory not found")),
     }
-    Ok(home)
 }
 
 const DEFAULT_TOKEN_GCP_URI: &str = "https://accounts.google.com/o/oauth2/token";


### PR DESCRIPTION
On Windows, the default credentials file is located in the `%APPDATA%\gcloud\application_default_credentials.json`. The existing implementation was looking for credentials in
`$HOME/.config/gcloud/application_default_credentials.json`, which only works on MacOS and Linux.

This change creates a `config_dir()` function that has different implementations for Linux/MacOS and Windows platforms, and returns the appropriate path for each.