### PR TITLE
Use `gcloud.cmd` to invoke `gcloud` on Windows

### DIFF
--- a/src/gcloud_authorized_user.rs
+++ b/src/gcloud_authorized_user.rs
@@ -59,7 +59,7 @@ impl TokenProvider for GCloudAuthorizedUser {
 }
 
 fn run(cmd: &[&str]) -> Result<String, Error> {
-    let mut command = Command::new("gcloud");
+    let mut command = Command::new(GCLOUD_CMD);
     command.args(cmd);
 
     let mut stdout = match command.output() {
@@ -74,6 +74,12 @@ fn run(cmd: &[&str]) -> Result<String, Error> {
 
     String::from_utf8(stdout).map_err(|_| Error::Str("output from `gcloud` is not UTF-8"))
 }
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const GCLOUD_CMD: &str = "gcloud";
+
+#[cfg(target_os = "windows")]
+const GCLOUD_CMD: &str = "gcloud.cmd";
 
 /// The default number of seconds that it takes for a Google Cloud auth token to expire.
 /// This appears to be the default from practical testing, but we have not found evidence


### PR DESCRIPTION
On Windows, the name of the `gcloud` command is `gcloud.cmd`, while on MacOS and Linux the name is just `gcloud`.

While on the Windows Command prompt invoking `gcloud` works, this is not the case when a process is spawned with Rust's `Command`, causing the application to fail to execute the command.

As a solution, we introduce an OS specific variable reflecting the actual command name for each OS.

Closes #111 