### PR TITLE
Update simple usage text on `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,13 @@ This crate does not currently support Windows.
 
 ## Simple usage
 
-The default way to use this library is to get instantiate an `AuthenticationManager`. It will
+The default way to use this library is to select the appropriate token provider using `provider()`. It will
 find the appropriate authentication method and use it to retrieve tokens.
 
 ```rust,no_run
-use gcp_auth::AuthenticationManager;
-
-let authentication_manager = AuthenticationManager::new().await?;
+let provider = gcp_auth::provider().await?;
 let scopes = &["https://www.googleapis.com/auth/cloud-platform"];
-let token = authentication_manager.get_token(scopes).await?;
+let token = provider.token(scopes).await?;
 ```
 
 # License


### PR DESCRIPTION
The `AuthenticationManager` struct has been removed and replaced with the `provider()` method, making the instructions on `README.md` outdated.

This PR is a minimal change to correct the documentation, based on the example in the rustdoc on lib.rs.